### PR TITLE
Revert "temporary redirect for hackweek"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,6 @@
     <!-- https://github.com/dcramer/mitsuhiko.at -->
     <title>mitsuhiko.at</title>
     <link rel="icon" href="favicon.ico?v=1" />
-    <!-- TODO(markus): Remove after hackweek -->
-    <meta http-equiv="refresh" content="0;URL='https://hackweek.getsentry.net/projects/-MfluTxe6km36Vh7usBQ/holzkurbelmodem'" />
     <link
       href="https://fonts.googleapis.com/css?family=Baloo+Bhai"
       rel="stylesheet"


### PR DESCRIPTION
This was done temporarily because our hackweek submission video referenced this domain and we only later realized that we didn't put the project name or a call to vote into the video. Now that hackweek is over I think it's time to unbreak the site again

Reverts dcramer/mitsuhiko.at#1